### PR TITLE
AntMe: Upgrade solution to VS 2019

### DIFF
--- a/AntMe.sln
+++ b/AntMe.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedComponents", "SharedComponents\SharedComponents.csproj", "{415F50C3-BD70-4634-B1F7-A15B42F0B0C6}"
 EndProject
@@ -128,58 +128,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(TeamFoundationVersionControl) = preSolution
-		SccNumberOfProjects = 17
-		SccEnterpriseProvider = {4CA58AB2-18FA-4F8D-95D4-32DDF27D184C}
-		SccTeamFoundationServer = https://antmeonline.visualstudio.com/defaultcollection
-		SccLocalPath0 = .
-		SccProjectUniqueName1 = SharedComponents\\SharedComponents.csproj
-		SccProjectName1 = SharedComponents
-		SccLocalPath1 = SharedComponents
-		SccProjectUniqueName2 = AntMe\\AntMe.csproj
-		SccProjectName2 = AntMe
-		SccLocalPath2 = AntMe
-		SccProjectUniqueName3 = DemoAmeisen\\DemoAmeisen.csproj
-		SccProjectName3 = DemoAmeisen
-		SccLocalPath3 = DemoAmeisen
-		SccProjectUniqueName4 = GdiPlusPlugin\\GdiPlusPlugin.csproj
-		SccProjectName4 = GdiPlusPlugin
-		SccLocalPath4 = GdiPlusPlugin
-		SccProjectUniqueName5 = SimulationCore\\SimulationCore.csproj
-		SccProjectName5 = SimulationCore
-		SccLocalPath5 = SimulationCore
-		SccProjectUniqueName6 = SimulationPlugin\\SimulationPlugin.csproj
-		SccProjectName6 = SimulationPlugin
-		SccLocalPath6 = SimulationPlugin
-		SccProjectUniqueName7 = XnaPlugin\\XnaPlugin\\XnaPlugin.csproj
-		SccProjectName7 = XnaPlugin/XnaPlugin
-		SccLocalPath7 = XnaPlugin\\XnaPlugin
-		SccProjectUniqueName8 = AntMe.Online.Client\\AntMe.Online.Client.csproj
-		SccProjectName8 = AntMe.Online.Client
-		SccLocalPath8 = AntMe.Online.Client
-		SccProjectUniqueName9 = OnlinePlugin\\OnlinePlugin.csproj
-		SccProjectName9 = OnlinePlugin
-		SccLocalPath9 = OnlinePlugin
-		SccProjectUniqueName10 = Setup\\Setup.wixproj
-		SccProjectName10 = Setup
-		SccLocalPath10 = Setup
-		SccProjectUniqueName11 = XnaPlugin\\XnaPluginContent\\XnaPluginContent.contentproj
-		SccProjectName11 = XnaPlugin/XnaPluginContent
-		SccLocalPath11 = XnaPlugin\\XnaPluginContent
-		SccProjectUniqueName12 = VideoPlugin\\VideoPlugin.csproj
-		SccProjectName12 = VideoPlugin
-		SccLocalPath12 = VideoPlugin
-		SccProjectUniqueName13 = PlayerManagement\\PlayerManagement.csproj
-		SccProjectName13 = PlayerManagement
-		SccLocalPath13 = PlayerManagement
-		SccProjectUniqueName14 = Help.English\\Help.English.shfbproj
-		SccProjectName14 = Help.English
-		SccLocalPath14 = Help.English
-		SccProjectUniqueName15 = Help.Deutsch\\Help.Deutsch.shfbproj
-		SccProjectName15 = Help.Deutsch
-		SccLocalPath15 = Help.Deutsch
-		SccProjectUniqueName16 = Help.SDK\\Help.SDK.shfbproj
-		SccProjectName16 = Help.SDK
-		SccLocalPath16 = Help.SDK
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {211EB653-1B4C-49C1-B89F-6679A2F14822}
 	EndGlobalSection
 EndGlobal

--- a/Help.Deutsch/Help.Deutsch.shfbproj
+++ b/Help.Deutsch/Help.Deutsch.shfbproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
 				 project documentation sources -->
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>70390b5e-0ce3-4f2d-9ba7-68f948d9d5f3</ProjectGuid>
-    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
+    <SHFBSchemaVersion>2017.9.26.0</SHFBSchemaVersion>
     <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
     <AssemblyName>Help.Deutsch</AssemblyName>
     <RootNamespace>Help.Deutsch</RootNamespace>
@@ -55,7 +55,7 @@
       <Filter entryType="Namespace" fullName="AntMe.SharedComponents.Tools" isExposed="False" />
       <Filter entryType="Namespace" fullName="AntMe.Simulation" isExposed="False" />
     </ApiFilter>
-    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected</VisibleItems>
+    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
     <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
     <HelpFileFormat>HtmlHelp1</HelpFileFormat>
     <IndentHtml>False</IndentHtml>

--- a/Help.English/Help.English.shfbproj
+++ b/Help.English/Help.English.shfbproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
 				 project documentation sources -->
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>bb67687e-a69b-4f7b-88b0-1dbbfdf74203</ProjectGuid>
-    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
+    <SHFBSchemaVersion>2017.9.26.0</SHFBSchemaVersion>
     <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
     <AssemblyName>Help.English</AssemblyName>
     <RootNamespace>Help.English</RootNamespace>
@@ -55,7 +55,7 @@
       <Filter entryType="Namespace" fullName="AntMe.SharedComponents.Tools" isExposed="False" xmlns="" />
       <Filter entryType="Namespace" fullName="AntMe.Simulation" isExposed="False" xmlns="" />
     </ApiFilter>
-    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected</VisibleItems>
+    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
     <WorkingPath>
     </WorkingPath>
     <PostBuildEvent>XCOPY "$(OutputPath)$(HtmlHelpName).chm*" "$(SolutionDir)bin\english\$(HtmlHelpName).chm*" /Y /C</PostBuildEvent>

--- a/Help.SDK/Help.SDK.shfbproj
+++ b/Help.SDK/Help.SDK.shfbproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
 				 project documentation sources -->
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>dbc732ed-cb38-41f5-be5a-ec4e6aee39d0</ProjectGuid>
-    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
+    <SHFBSchemaVersion>2017.9.26.0</SHFBSchemaVersion>
     <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
     <AssemblyName>Help.SDK</AssemblyName>
     <RootNamespace>Help.SDK</RootNamespace>
@@ -52,7 +52,7 @@
       <Filter entryType="Namespace" fullName="AntMe.Deutsch" isExposed="False" xmlns="" />
       <Filter entryType="Namespace" fullName="AntMe.English" isExposed="False" xmlns="" />
     </ApiFilter>
-    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected</VisibleItems>
+    <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
     <WorkingPath>
     </WorkingPath>
     <PostBuildEvent>XCOPY "$(OutputPath)$(HtmlHelpName).chm*" "$(SolutionDir)bin\$(HtmlHelpName).chm*" /Y /C</PostBuildEvent>


### PR DESCRIPTION
Upgraded solution to Visual Studio 2019.
Steps:
- Installed XNA via http://flatredball.com/visual-studio-2019-xna-setup/
- Installed Sandcastle via https://github.com/EWSoftware/SHFB
- Ran as admin in Developer Command Prompt for VS 2019:
```
cd C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\amd64
gacutil /i Microsoft.Build.Framework.dll
```
- Ran Visual Studio 2019 as admin

I am unsure what the side effects of the removal of TFS preSolution are.
Please also check automatic additions of EditorBrowsableNever, NonBrowsable

Solution builds and AntMe simulation runs fine.

This post/private work represents my own opinions.