### PR TITLE
AneMe: Change xna language to English if system not configured to German

### DIFF
--- a/XnaPlugin/XnaPlugin/RenderWindow.cs
+++ b/XnaPlugin/XnaPlugin/RenderWindow.cs
@@ -81,8 +81,11 @@ namespace AntMe.Plugin.Xna
             camera = new Camera(Window);
             previousKeyboardState = Keyboard.GetState();
 
-            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de");
-            Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("de");
+            if (!string.Equals(Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName, "de", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en");
+                Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en");
+            }
 
             base.Initialize();
         }


### PR DESCRIPTION
Currently XNA language is always set to "de". This change keeps "de" if "de" is system language and otherwise switches to "en".