### PR TITLE
[#52] Make sure the debug message cache gets cleared

### DIFF
--- a/FnaPlugin/RenderWindow.cs
+++ b/FnaPlugin/RenderWindow.cs
@@ -178,6 +178,11 @@ namespace AntMe.Plugin.Fna
         }
 
         /// <summary>
+        /// Stores the round id of the latest render cycle
+        /// </summary>
+        private int? latestRenderedRound;
+
+        /// <summary>
         /// Allows the game to run logic such as updating the world,
         /// checking for collisions, gathering input, and playing audio.
         /// </summary>
@@ -189,6 +194,14 @@ namespace AntMe.Plugin.Fna
                 playgroundWidth = CurrentState.PlaygroundWidth / 2;
                 playgroundHeight = CurrentState.PlaygroundHeight / 2;
                 camera.Resize(CurrentState.PlaygroundWidth, CurrentState.PlaygroundHeight);
+
+                // Detect new round to reset debug messages
+                if (!latestRenderedRound.HasValue || latestRenderedRound > CurrentState.CurrentRound)
+                {
+                    debugMessages.Clear();
+                }
+
+                latestRenderedRound = CurrentState.CurrentRound;
             }
 
             var ks = Keyboard.GetState();


### PR DESCRIPTION
According to the bug #52 old debug messages from previous rounds appeared in upcoming simulation rounds - mapped by the object id. So thinking bubbles from other colonies popped up on totally wrong ants.

This PR makes sure the message cache on UI side gets cleared as soon as a new round starts.

This was not a security critial thing, but a UI fix.